### PR TITLE
Major ControlManager refactor

### DIFF
--- a/base/ControllableChar.ts
+++ b/base/ControllableChar.ts
@@ -270,7 +270,7 @@ export class ControllableChar {
             if (this.footsteps.can_make_footprint && footsteps) {
                 this.footsteps.create_step(this.current_direction, this.current_action);
             }
-            const shift_pressed = this.game.input.keyboard.isDown(Phaser.Keyboard.SHIFT);
+            const shift_pressed = this.game.input.keyboard.isDown(this.data.gamepad.B);
             if (shift_pressed && this.current_action !== base_actions.DASH) {
                 this.current_action = base_actions.DASH;
             } else if (!shift_pressed && this.current_action !== base_actions.WALK) {

--- a/base/Gamepad.ts
+++ b/base/Gamepad.ts
@@ -1,16 +1,3 @@
-export type BaseInputs = {
-    LEFT:number,
-    RIGHT:number,
-    UP:number,
-    DOWN:number,
-    A:number,
-    B:number,
-    L?:number,
-    R?:number,
-    SELECT?:number,
-    START?:number,
-}
-
 export const extra_input_labels = {
     PSY1: "psy1",
     PSY2: "psy2",

--- a/base/Gamepad.ts
+++ b/base/Gamepad.ts
@@ -1,0 +1,161 @@
+export type BaseInputs = {
+    LEFT:number,
+    RIGHT:number,
+    UP:number,
+    DOWN:number,
+    A:number,
+    B:number,
+    L?:number,
+    R?:number,
+    SELECT?:number,
+    START?:number,
+}
+
+export const extra_input_labels = {
+    PSY1: "psy1",
+    PSY2: "psy2",
+    PSY3: "psy3",
+    ZOOM1: "zoom1",
+    ZOOM2: "zoom2",
+    ZOOM3: "zoom3",
+    DEBUG_PHYS: "debug_phys",
+    GRID: "grid",
+    KEYS: "keys",
+    STATS: "stats",
+    FPS: "fps",
+    SLIDERS: "sliders",
+    BATTLE_CAM_PLUS: "battle_cam_plus",
+    BATTLE_CAM_MINUS: "battle_cam_minus"
+}
+
+export class Gamepad{
+    public LEFT:number;
+    public RIGHT:number;
+    public UP:number;
+    public DOWN:number;
+
+    public A:number;
+    public B:number;
+    public L:number;
+    public R:number;
+
+    public SELECT:number;
+    public START:number;
+
+    public extra_inputs:{label:string, key:number}[];
+
+    constructor(){
+        this.initialize_gamepad();
+    }
+
+    initialize_gamepad(){
+        let base = {
+            LEFT: Phaser.Keyboard.LEFT,
+            RIGHT: Phaser.Keyboard.RIGHT,
+            UP: Phaser.Keyboard.UP,
+            DOWN: Phaser.Keyboard.DOWN,
+            A: Phaser.Keyboard.Z, //previously ENTER
+            B: Phaser.Keyboard.X, //previously ESC
+            L: Phaser.Keyboard.A, //previously SHIFT
+            R: Phaser.Keyboard.S, //previously SPACEBAR
+            SELECT: Phaser.Keyboard.BACKSPACE,
+            START: Phaser.Keyboard.ENTER
+        };
+
+        let extra = [
+            {label: extra_input_labels.PSY1, key: Phaser.Keyboard.Q},
+            {label: extra_input_labels.PSY2, key: Phaser.Keyboard.W},
+            {label: extra_input_labels.PSY3, key: Phaser.Keyboard.E},
+            {label: extra_input_labels.ZOOM1, key: Phaser.Keyboard.ONE},
+            {label: extra_input_labels.ZOOM2, key: Phaser.Keyboard.TWO},
+            {label: extra_input_labels.ZOOM3, key: Phaser.Keyboard.THREE},
+            {label: extra_input_labels.DEBUG_PHYS, key: Phaser.Keyboard.D},
+            {label: extra_input_labels.GRID, key: Phaser.Keyboard.G},
+            {label: extra_input_labels.KEYS, key: Phaser.Keyboard.K},
+            {label: extra_input_labels.STATS, key: Phaser.Keyboard.S},
+            {label: extra_input_labels.FPS, key: Phaser.Keyboard.F},
+            {label: extra_input_labels.SLIDERS, key: Phaser.Keyboard.L},
+            {label: extra_input_labels.BATTLE_CAM_MINUS, key: Phaser.Keyboard.PAGE_DOWN},
+            {label: extra_input_labels.BATTLE_CAM_PLUS, key: Phaser.Keyboard.PAGE_UP},
+        ];
+
+        this.LEFT = base.LEFT;
+        this.RIGHT = base.RIGHT;
+        this.UP = base.UP;
+        this.DOWN = base.DOWN;
+
+        this.A = base.A;
+        this.B = base.B;
+        this.L = base.L;
+        this.R = base.R;
+
+        this.SELECT = base.SELECT;
+        this.START= base.START;
+
+        this.extra_inputs = extra ? extra : [];
+    }
+
+    opposite_key(key:number){
+        switch(key){
+            case this.LEFT: return this.RIGHT;
+            case this.RIGHT: return this.LEFT;
+            case this.UP: return this.DOWN;
+            case this.DOWN: return this.UP;
+
+            case this.A: return this.B;
+            case this.B: return this.A;
+            case this.L: return this.R;
+            case this.R: return this.L;
+            
+            case this.SELECT: return this.START;
+            case this.START: return this.SELECT;
+
+            default: return null;
+        }
+    }
+
+    get_key_by_label(label:string){
+        for(let i=0; i<this.extra_inputs.length; i++){
+            if(this.extra_inputs[i].label === label)
+                return this.extra_inputs[i].key; 
+        }
+        return null;
+    }
+
+    get_label_by_key(key:number){
+        for(let i=0; i<this.extra_inputs.length; i++){
+            if(this.extra_inputs[i].key === key)
+                return this.extra_inputs[i].label; 
+        }
+        return null;
+    }
+
+    get main_keys(){
+        let keys:number[] = [];
+
+        if(this.LEFT) keys.push(this.LEFT);
+        if(this.RIGHT) keys.push(this.RIGHT);
+        if(this.UP) keys.push(this.UP);
+        if(this.DOWN) keys.push(this.DOWN);
+
+        if(this.A) keys.push(this.A);
+        if(this.B) keys.push(this.B);
+        if(this.L) keys.push(this.L);
+        if(this.R) keys.push(this.R);
+
+        if(this.SELECT) keys.push(this.SELECT);
+        if(this.START) keys.push(this.START);
+
+        return keys;
+    }
+
+    get extra_keys(){
+        let keys:number[] = [];
+
+        this.extra_inputs.forEach(obj => {keys.push(obj.key)});
+
+        return keys;
+    }
+
+
+}

--- a/base/GoldenSun.ts
+++ b/base/GoldenSun.ts
@@ -40,12 +40,6 @@ export class GoldenSun {
     public game_event_manager: GameEventManager = null; //class responsible for the game events
     public battle_instance: Battle = null;              //class responsible for a battle
 
-    //inputs
-    public enter_input: Phaser.Signal = null;
-    public esc_input: Phaser.Signal = null;
-    public shift_input: Phaser.Signal = null;
-    public spacebar_input: Phaser.Signal = null;
-
     //managers
     public control_manager: ControlManager = null;
     public cursor_manager: CursorManager = null;

--- a/base/GoldenSun.ts
+++ b/base/GoldenSun.ts
@@ -15,6 +15,7 @@ import { MainMenu, initialize_menu } from './main_menus/MainMenu';
 import { ShopMenu } from './main_menus/ShopMenu';
 import { ControlManager } from './utils/ControlManager';
 import { CursorManager } from './utils/CursorManager';
+import { Gamepad, extra_input_labels } from './Gamepad';
 
 export class GoldenSun {
     public game: Phaser.Game = null;
@@ -48,6 +49,7 @@ export class GoldenSun {
     //managers
     public control_manager: ControlManager = null;
     public cursor_manager: CursorManager = null;
+    public gamepad: Gamepad = null;
 
     //variables that control the canvas
     public fullscreen: boolean = false;
@@ -99,11 +101,10 @@ export class GoldenSun {
         //load some json files from assets folder
         load_databases(this.game, this.dbs);
 
-        //initialize common inputs
-        this.enter_input = this.game.input.keyboard.addKey(Phaser.Keyboard.ENTER).onDown;
-        this.esc_input = this.game.input.keyboard.addKey(Phaser.Keyboard.ESC).onDown;
-        this.shift_input = this.game.input.keyboard.addKey(Phaser.Keyboard.SHIFT).onDown;
-        this.spacebar_input = this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR).onDown;
+        //initialize managers
+        this.gamepad = new Gamepad();
+        this.cursor_manager = new CursorManager(this.game);
+        this.control_manager = new ControlManager(this.game, this.gamepad);
 
         this.scale_factor = this.dbs.init_db.initial_scale_factor;
 
@@ -176,46 +177,58 @@ export class GoldenSun {
         });
 
         //enable zoom
-        this.game.input.keyboard.addKey(Phaser.Keyboard.ONE).onDown.add(() => {
-            if (this.fullscreen) return;
-            this.scale_factor = 1;
-            this.game.scale.setupScale(numbers.GAME_WIDTH, numbers.GAME_HEIGHT);
-            window.dispatchEvent(new Event('resize'));
-        });
-        this.game.input.keyboard.addKey(Phaser.Keyboard.TWO).onDown.add(() => {
-            if (this.fullscreen) return;
-            this.scale_factor = 2;
-            this.game.scale.setupScale(this.scale_factor * numbers.GAME_WIDTH, this.scale_factor * numbers.GAME_HEIGHT);
-            window.dispatchEvent(new Event('resize'));
-        });
-        this.game.input.keyboard.addKey(Phaser.Keyboard.THREE).onDown.add(() => {
-            if (this.fullscreen) return;
-            this.scale_factor = 3;
-            this.game.scale.setupScale(this.scale_factor * numbers.GAME_WIDTH, this.scale_factor * numbers.GAME_HEIGHT);
-            window.dispatchEvent(new Event('resize'));
-        });
+        this.control_manager.add_fleeting_control(this.gamepad.get_key_by_label(extra_input_labels.ZOOM1), {
+            on_down: () => {
+                if (this.fullscreen) return;
+                this.scale_factor = 1;
+                this.game.scale.setupScale(numbers.GAME_WIDTH, numbers.GAME_HEIGHT);
+                window.dispatchEvent(new Event('resize'));
+            }
+        }, {persist:true});
 
-        //initialize managers
-        this.cursor_manager = new CursorManager(this.game);
-        this.control_manager = new ControlManager(this.game);
+        this.control_manager.add_fleeting_control(this.gamepad.get_key_by_label(extra_input_labels.ZOOM2), {
+            on_down: () => {
+                if (this.fullscreen) return;
+                this.scale_factor = 2;
+                this.game.scale.setupScale(this.scale_factor * numbers.GAME_WIDTH, this.scale_factor * numbers.GAME_HEIGHT);
+                window.dispatchEvent(new Event('resize'));
+            }
+        }, {persist:true});
+
+        this.control_manager.add_fleeting_control(this.gamepad.get_key_by_label(extra_input_labels.ZOOM3), {
+            on_down: () => {
+                if (this.fullscreen) return;
+                this.scale_factor = 3;
+                this.game.scale.setupScale(this.scale_factor * numbers.GAME_WIDTH, this.scale_factor * numbers.GAME_HEIGHT);
+                window.dispatchEvent(new Event('resize'));
+            }
+        }, {persist:true});
 
         //initialize screens
         this.shop_menu = new ShopMenu(this.game, this);
         this.main_menu = initialize_menu(this.game, this);
 
         //enable psynergies shortcuts for testing
-        this.game.input.keyboard.addKey(Phaser.Keyboard.Q).onDown.add(() => {
-            if (this.hero.in_action() || this.menu_open || this.in_battle || this.shop_open) return;
-            this.info.field_abilities_list.move.cast(this.hero, this.dbs.init_db.initial_shortcuts.move);
-        });
-        this.game.input.keyboard.addKey(Phaser.Keyboard.W).onDown.add(() => {
-            if (this.hero.in_action() || this.menu_open || this.in_battle || this.shop_open) return;
-            this.info.field_abilities_list.frost.cast(this.hero, this.dbs.init_db.initial_shortcuts.frost);
-        });
-        this.game.input.keyboard.addKey(Phaser.Keyboard.E).onDown.add(() => {
-            if (this.hero.in_action() || this.menu_open || this.in_battle || this.shop_open) return;
+        this.control_manager.add_fleeting_control(this.gamepad.get_key_by_label(extra_input_labels.PSY1), {
+            on_down: () => {
+                if (this.hero.in_action() || this.menu_open || this.in_battle || this.shop_open) return;
+                this.info.field_abilities_list.move.cast(this.hero, this.dbs.init_db.initial_shortcuts.move);
+            }
+        }, {persist:true});
+
+        this.control_manager.add_fleeting_control(this.gamepad.get_key_by_label(extra_input_labels.PSY2), {
+            on_down: () => {
+                if (this.hero.in_action() || this.menu_open || this.in_battle || this.shop_open) return;
+                this.info.field_abilities_list.frost.cast(this.hero, this.dbs.init_db.initial_shortcuts.frost);
+            }
+        }, {persist:true});
+
+        this.control_manager.add_fleeting_control(this.gamepad.get_key_by_label(extra_input_labels.PSY3), {
+            on_down: () => {
+                if (this.hero.in_action() || this.menu_open || this.in_battle || this.shop_open) return;
             this.info.field_abilities_list.growth.cast(this.hero, this.dbs.init_db.initial_shortcuts.growth);
-        });
+            }
+        }, {persist:true});
     }
 
     hero_movement_allowed(allow_climbing = true) {

--- a/base/Hero.ts
+++ b/base/Hero.ts
@@ -57,20 +57,18 @@ const speeds = {
 
 export class Hero extends ControllableChar {
     public arrow_inputs: number;
-    public cursors: Phaser.CursorKeys;
 
     constructor(game, data, key_name, initial_x, initial_y, initial_action, initial_direction) {
         super(game, data, key_name, initial_x, initial_y, initial_action, initial_direction, true);
         this.arrow_inputs = null;
-        this.cursors = this.game.input.keyboard.createCursorKeys();
     }
 
     update_arrow_inputs() {
         this.arrow_inputs =
-              1 * (+this.cursors.right.isDown)
-            | 2 * (+this.cursors.left.isDown)
-            | 4 * (+this.cursors.up.isDown)
-            | 8 * (+this.cursors.down.isDown);
+              1 * (+this.game.input.keyboard.isDown(this.data.gamepad.RIGHT))
+            | 2 * (+this.game.input.keyboard.isDown(this.data.gamepad.LEFT))
+            | 4 * (+this.game.input.keyboard.isDown(this.data.gamepad.UP))
+            | 8 * (+this.game.input.keyboard.isDown(this.data.gamepad.DOWN));
         this.required_direction = rotation_key[this.arrow_inputs];
     }
 

--- a/base/battle/BattleStage.ts
+++ b/base/battle/BattleStage.ts
@@ -9,6 +9,7 @@ import * as _ from "lodash";
 import { SpriteBase } from '../SpriteBase';
 import { MainChar } from '../MainChar';
 import { Enemy } from '../Enemy';
+import { extra_input_labels } from '../Gamepad';
 
 const SCALE_FACTOR = 0.8334;
 const BG_X = 0;
@@ -476,12 +477,12 @@ export class BattleStage {
                 this.choosing_targets = true;
                 this.change_target(0, false);
 
-                this.data.control_manager.set_control({
+                this.data.control_manager.set_main_control({
                     right: this.previous_target.bind(this),
                     left: this.next_target.bind(this),
-                    enter: this.set_targets.bind(this),
-                    esc: this.choosing_targets_finished.bind(this, null)
-                },{horizontal_loop:true})
+                    a: this.set_targets.bind(this),
+                    b: this.choosing_targets_finished.bind(this, null)
+                },{loop_configs: {horizontal:true}});
             });
         }
     }
@@ -504,10 +505,13 @@ export class BattleStage {
     update_stage() {
         if (this.choosing_actions) return;
 
-        if (!this.game.input.keyboard.isDown(Phaser.Keyboard.PAGE_UP) && this.game.input.keyboard.isDown(Phaser.Keyboard.PAGE_DOWN)) {
+        let cam_plus_key = this.data.gamepad.get_key_by_label(extra_input_labels.BATTLE_CAM_PLUS);
+        let cam_minus_key = this.data.gamepad.get_key_by_label(extra_input_labels.BATTLE_CAM_MINUS);
+
+        if (!this.game.input.keyboard.isDown(cam_plus_key) && this.game.input.keyboard.isDown(cam_minus_key)) {
             this.camera_angle.rad -= CAMERA_SPEED;
             this.battle_bg.x -= BG_SPEED
-        } else if (this.game.input.keyboard.isDown(Phaser.Keyboard.PAGE_UP) && !this.game.input.keyboard.isDown(Phaser.Keyboard.PAGE_DOWN)) {
+        } else if (this.game.input.keyboard.isDown(cam_plus_key) && !this.game.input.keyboard.isDown(cam_minus_key)) {
             this.camera_angle.rad += CAMERA_SPEED;
             this.battle_bg.x += BG_SPEED
         } else {

--- a/base/debug/Debug.ts
+++ b/base/debug/Debug.ts
@@ -1,6 +1,7 @@
 import { GoldenSun } from "../GoldenSun";
 import { MainChar } from "../MainChar";
 import { reverse_directions, ordered_elements } from "../utils";
+import { extra_input_labels } from "../Gamepad";
 import * as _ from "lodash";
 
 export class Debug {
@@ -31,34 +32,46 @@ export class Debug {
 
     initialize_controls() {
         //activate debug mode
-        this.game.input.keyboard.addKey(Phaser.Keyboard.D).onDown.add(() => {
-            this.toggle_debug_physics();
-        });
-        
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.get_key_by_label(extra_input_labels.DEBUG_PHYS), {
+            on_down: () => {
+                this.toggle_debug_physics();
+            }
+        }, {persist:true});
+
         //activate grid mode
-        this.game.input.keyboard.addKey(Phaser.Keyboard.G).onDown.add(() => {
-            this.toggle_grid();
-        }, this);
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.get_key_by_label(extra_input_labels.GRID), {
+            on_down: () => {
+                this.toggle_grid();
+            }
+        }, {persist:true});
 
         //activate keys debug mode
-        this.game.input.keyboard.addKey(Phaser.Keyboard.K).onDown.add(() => {
-            this.toggle_keys();
-        }, this);
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.get_key_by_label(extra_input_labels.KEYS), {
+            on_down: () => {
+                this.toggle_keys();
+            }
+        }, {persist:true});
 
         //activate stats debug mode
-        this.game.input.keyboard.addKey(Phaser.Keyboard.S).onDown.add(() => {
-            this.toggle_stats();
-        }, this);
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.get_key_by_label(extra_input_labels.STATS), {
+            on_down: () => {
+                this.toggle_stats();
+            }
+        }, {persist:true});
 
         //enable fps show
-        this.game.input.keyboard.addKey(Phaser.Keyboard.F).onDown.add(() => {
-            this.toggle_fps();
-        }, this);
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.get_key_by_label(extra_input_labels.FPS), {
+            on_down: () => {
+                this.toggle_fps();
+            }
+        }, {persist:true});
 
         //show sliders
-        this.game.input.keyboard.addKey(Phaser.Keyboard.L).onDown.add(() => {
-            this.toggle_sliders();
-        }, this);
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.get_key_by_label(extra_input_labels.SLIDERS), {
+            on_down: () => {
+                this.toggle_sliders();
+            }
+        }, {persist:true});
     }
 
     update_debug_physics(flag) {

--- a/base/field_abilities/GrowthFieldPsynergy.ts
+++ b/base/field_abilities/GrowthFieldPsynergy.ts
@@ -134,7 +134,7 @@ export class GrowthFieldPsynergy extends FieldAbilities {
         let promises = new Array(NO_TARGET_SPROUT_COUNT);
         const variation = 13;
         for (let i = 0; i < NO_TARGET_SPROUT_COUNT; ++i) {
-            let miss_target_sprite = this.data.overlayer_group.create(grow_center_x + _.random(-variation, variation), grow_center_y + _.random(-variation, variation), "growth");
+            let miss_target_sprite = this.data.overlayer_group.create(grow_center_x + _.random(-variation, variation), grow_center_y + _.random(-variation, variation), "growth_growth");
             miss_target_sprite.anchor.setTo(0.5, 1);
             miss_target_sprite.animations.add("no_target", frames, 10, false, false);
             let resolve_func;

--- a/base/field_abilities/GrowthFieldPsynergy.ts
+++ b/base/field_abilities/GrowthFieldPsynergy.ts
@@ -134,7 +134,7 @@ export class GrowthFieldPsynergy extends FieldAbilities {
         let promises = new Array(NO_TARGET_SPROUT_COUNT);
         const variation = 13;
         for (let i = 0; i < NO_TARGET_SPROUT_COUNT; ++i) {
-            let miss_target_sprite = this.data.overlayer_group.create(grow_center_x + _.random(-variation, variation), grow_center_y + _.random(-variation, variation), "growth_growth");
+            let miss_target_sprite = this.data.overlayer_group.create(grow_center_x + _.random(-variation, variation), grow_center_y + _.random(-variation, variation), "growth");
             miss_target_sprite.anchor.setTo(0.5, 1);
             miss_target_sprite.animations.add("no_target", frames, 10, false, false);
             let resolve_func;

--- a/base/game_events/GameEventManager.ts
+++ b/base/game_events/GameEventManager.ts
@@ -25,15 +25,17 @@ export class GameEventManager {
     }
 
     set_controls() {
-        this.data.enter_input.add(() => {
-            if (this.data.hero.in_action() || this.data.in_battle || !this.control_enable) return;
-            if (this.on_event) {
-                this.control_enable = false;
-                this.fire_next_step();
-            } else {
-                this.search_for_npc();
+        this.data.control_manager.add_fleeting_control(this.data.gamepad.A, {
+            on_down: () => {
+                if (this.data.hero.in_action() || this.data.in_battle || !this.control_enable) return;
+                if (this.on_event) {
+                    this.control_enable = false;
+                    this.fire_next_step();
+                } else {
+                    this.search_for_npc();
+                }
             }
-        });
+        }, {persist:true});
     }
 
     search_for_npc() {

--- a/base/main_menus/MainBattleMenu.ts
+++ b/base/main_menus/MainBattleMenu.ts
@@ -209,7 +209,7 @@ export class MainBattleMenu {
                 }
 
                 this.description_window.hide();
-                this.choose_targets(ability, action_type, targets => {
+                this.choose_targets(ability, action_type, (targets:Target[]) => {
                     if (targets) {
                         this.abilities[this.data.info.party_data.members[this.current_char_index].key_name].push({
                             key_name: ability,

--- a/base/main_menus/MainMenu.ts
+++ b/base/main_menus/MainMenu.ts
@@ -113,5 +113,17 @@ export function initialize_menu(game:Phaser.Game, data:GoldenSun) {
         }
     }, {persist:true});
 
+    data.control_manager.add_fleeting_control(data.gamepad.SELECT, {
+        on_down: () => {
+            if (data.hero.in_action() || data.in_battle || !data.created || data.game_event_manager.on_event) return;
+            if (!data.menu_open) {
+                data.menu_open = true;
+                data.hero.stop_char();
+                data.hero.update_shadow();
+                data.main_menu.open_menu();
+            }
+        }
+    }, {persist:true});
+
     return new MainMenu(game, data);
 }

--- a/base/main_menus/MainMenu.ts
+++ b/base/main_menus/MainMenu.ts
@@ -101,28 +101,22 @@ export class MainMenu {
 }
 
 export function initialize_menu(game:Phaser.Game, data:GoldenSun) {
+    let open_func = () => {
+        if (data.hero.in_action() || data.in_battle || !data.created || data.game_event_manager.on_event) return;
+        if (!data.menu_open) {
+            data.menu_open = true;
+            data.hero.stop_char();
+            data.hero.update_shadow();
+            data.main_menu.open_menu();
+        };
+    }
+
     data.control_manager.add_fleeting_control(data.gamepad.A, {
-        on_down: () => {
-            if (data.hero.in_action() || data.in_battle || !data.created || data.game_event_manager.on_event) return;
-            if (!data.menu_open) {
-                data.menu_open = true;
-                data.hero.stop_char();
-                data.hero.update_shadow();
-                data.main_menu.open_menu();
-            }
-        }
+        on_down: open_func
     }, {persist:true});
 
     data.control_manager.add_fleeting_control(data.gamepad.SELECT, {
-        on_down: () => {
-            if (data.hero.in_action() || data.in_battle || !data.created || data.game_event_manager.on_event) return;
-            if (!data.menu_open) {
-                data.menu_open = true;
-                data.hero.stop_char();
-                data.hero.update_shadow();
-                data.main_menu.open_menu();
-            }
-        }
+        on_down: open_func
     }, {persist:true});
 
     return new MainMenu(game, data);

--- a/base/main_menus/MainMenu.ts
+++ b/base/main_menus/MainMenu.ts
@@ -101,16 +101,17 @@ export class MainMenu {
 }
 
 export function initialize_menu(game:Phaser.Game, data:GoldenSun) {
-    data.spacebar_input.add(() => {
-        if (data.hero.in_action() || data.in_battle || !data.created || data.game_event_manager.on_event) return;
-        if (!data.menu_open) {
-            data.menu_open = true;
-            data.hero.stop_char();
-            data.hero.update_shadow();
-            data.main_menu.open_menu();
-        } else if (data.main_menu.is_active()) {
-            data.main_menu.close_menu();
+    data.control_manager.add_fleeting_control(data.gamepad.A, {
+        on_down: () => {
+            if (data.hero.in_action() || data.in_battle || !data.created || data.game_event_manager.on_event) return;
+            if (!data.menu_open) {
+                data.menu_open = true;
+                data.hero.stop_char();
+                data.hero.update_shadow();
+                data.main_menu.open_menu();
+            }
         }
-    }, this);
+    }, {persist:true});
+
     return new MainMenu(game, data);
 }

--- a/base/main_menus/ShopMenu.ts
+++ b/base/main_menus/ShopMenu.ts
@@ -322,8 +322,6 @@ export class ShopMenu{
         this.artifact_list = {};
         this.current_index = 0;
 
-        this.data.control_manager.reset();
-        this.data.control_manager.actions["enter"].callback = this.end_dialog.bind(this);
-        this.data.control_manager.set_actions();
+        this.data.control_manager.simple_input(this.end_dialog.bind(this));
     }
 }

--- a/base/support_menus/CharsMenu.ts
+++ b/base/support_menus/CharsMenu.ts
@@ -306,12 +306,12 @@ export class CharsMenu {
     }
 
     grant_control(on_cancel:Function, on_select:Function){
-        this.data.control_manager.set_control({right: this.next_char.bind(this),
+        this.data.control_manager.set_main_control({right: this.next_char.bind(this),
             left: this.previous_char.bind(this),
             up: this.previous_line.bind(this),
             down: this.next_line.bind(this),
-            esc: on_cancel,
-            enter: on_select}, {horizontal_loop:true});
+            b: on_cancel,
+            a: on_select},{loop_configs: {horizontal:true}});
     }
 
     activate(){

--- a/base/support_menus/HorizontalMenu.ts
+++ b/base/support_menus/HorizontalMenu.ts
@@ -79,8 +79,8 @@ export class HorizontalMenu {
     }
 
     set_control() {
-        this.data.control_manager.set_control({right: this.next_button.bind(this), left: this.previous_button.bind(this),
-            esc: (this.on_cancel ? this.on_cancel.bind(this) : undefined), enter: this.on_press.bind(this)}, {horizontal_loop: true});
+        this.data.control_manager.set_main_control({right: this.next_button.bind(this), left: this.previous_button.bind(this),
+            b: (this.on_cancel ? this.on_cancel.bind(this) : undefined), a: this.on_press.bind(this)},{loop_configs: {horizontal:true}});
     }
 
     mount_buttons(filtered_buttons:string[]=[]) {

--- a/base/utils/ControlManager.ts
+++ b/base/utils/ControlManager.ts
@@ -1,4 +1,3 @@
-import { directions, action_inputs, get_opposite_direction } from '../utils';
 import * as _ from "lodash";
 import { Gamepad } from '../Gamepad';
 

--- a/base/utils/ControlManager.ts
+++ b/base/utils/ControlManager.ts
@@ -18,7 +18,7 @@ export type LoopConfigs = {
 
 export class ControlManager{
     public game:Phaser.Game;
-    public gamepad: Gamepad;
+    public gamepad:Gamepad;
     public disabled:boolean;
 
     public main_keys_list:number[];

--- a/base/windows/ItemPsynergyChooseWindow.ts
+++ b/base/windows/ItemPsynergyChooseWindow.ts
@@ -29,6 +29,8 @@ const CURSOR_X = 98;
 const CURSOR_Y = 42;
 const CURSOR_GAP = 16;
 
+const HORIZONTAL_LOOP_TIME = 300;
+
 /*Displays the character's Psynergy or Items
 Used in a selection-type menu, referring to the above
 
@@ -314,16 +316,16 @@ export class ItemPsynergyChooseWindow {
 
     /*Enables control keys for this menu*/
     grant_control(on_cancel:Function, on_select:Function, extra_commands?:{shift?:Function, spacebar?:Function}){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             right: this.next_page.bind(this),
             left: this.previous_page.bind(this),
             up: this.previous_element.bind(this),
             down: this.next_element.bind(this),
-            esc: on_cancel,
-            enter: on_select,
-            shift: extra_commands.shift,
-            spacebar: extra_commands.spacebar
-        },{horizontal_loop:true, vertical_loop:true});
+            b: on_cancel,
+            a: on_select,
+            l: extra_commands.shift,
+            r: extra_commands.spacebar
+        },{loop_configs: {vertical:true, horizontal:true, horizontal_time:HORIZONTAL_LOOP_TIME}});
     }
 
     /*Hides this window*/

--- a/base/windows/battle/DjinnWindow.ts
+++ b/base/windows/battle/DjinnWindow.ts
@@ -245,12 +245,12 @@ export class DjinnWindow {
         this.psynergy_window.open(this.char, undefined, undefined, true, this.data.info.djinni_list[this.djinni[this.djinn_index]], this.get_next_status());
         this.psynergy_window_open = true;
 
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             up: this.previous_djinn.bind(this),
             down: this.next_djinn.bind(this),
             left: this.psynergy_window.previous_page.bind(this.psynergy_window),
             right: this.psynergy_window.next_page.bind(this.psynergy_window)
-        },{vertical_loop:true, horizontal_loop:true});
+        },{loop_configs: {vertical:true, horizontal:true}});
     }
 
     hide_psynergy(){
@@ -264,26 +264,26 @@ export class DjinnWindow {
     }
 
     djinn_choose(){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             left: this.previous_page.bind(this),
             right: this.next_page.bind(this),
             up: this.previous_djinn.bind(this),
             down: this.next_djinn.bind(this),
-            esc: () => {
+            b: () => {
                 this.choosen_ability = null;
                 this.close(this.close_callback);
             },
-            enter: () => {
+            a: () => {
                 const this_djinn = this.data.info.djinni_list[this.djinni[this.djinn_index]];
                 if (this_djinn.status !== djinn_status.RECOVERY) {
                     this.choosen_ability = this_djinn.ability_key_name;
                     this.hide(this.close_callback);
                 }
             }
-        },{horizontal_loop:true, vertical_loop:true});
+        },{loop_configs: {vertical:true, horizontal:true}});
 
         if(this.shift_bindings.length === 0){
-            this.shift_bindings = this.data.control_manager.add_fleeting_control(action_inputs.SHIFT,
+            this.shift_bindings = this.data.control_manager.add_fleeting_control(this.data.gamepad.R,
                 {on_down: this.show_psynergy.bind(this), on_up: this.hide_psynergy.bind(this)},
                 {persist: true});
         }

--- a/base/windows/battle/ItemWindow.ts
+++ b/base/windows/battle/ItemWindow.ts
@@ -208,17 +208,17 @@ export class ItemWindow {
     }
 
     item_choose(){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             left: this.previous_page.bind(this),
             right: this.next_page.bind(this),
             up: this.previous_item.bind(this),
             down: this.next_item.bind(this),
-            esc: () => {
+            b: () => {
                 this.choosen_ability = null;
                 this.item_obj = null;
                 this.close(this.close_callback);
             },
-            enter: () => {
+            a: () => {
                 const this_item = this.data.info.items_list[this.items[this.item_index].key_name];
                 if (this_item.use_type !== use_types.NO_USE && this.data.info.abilities_list[this_item.use_ability].is_battle_ability) {
                     this.choosen_ability = this_item.use_ability;
@@ -226,7 +226,7 @@ export class ItemWindow {
                     this.hide(this.close_callback);
                 }
             }
-        },{horizontal_loop:true, vertical_loop:true});
+        },{loop_configs: {vertical:true, horizontal:true}});
     }
 
     open(char:MainChar, close_callback:Function, set_description:Function, ...args:any[]) {

--- a/base/windows/battle/PsynergyWindow.ts
+++ b/base/windows/battle/PsynergyWindow.ts
@@ -333,7 +333,7 @@ export class PsynergyWindow {
     }
 
     ability_choose(){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             left: this.previous_page.bind(this),
             right: this.next_page.bind(this),
             up: () => {
@@ -342,19 +342,19 @@ export class PsynergyWindow {
             down: () => {
                 if(!this.expanded) this.next_ability();
             },
-            esc: () => {
+            b: () => {
                 if(!this.expanded){
                     this.choosen_ability = null;
                     this.close(this.close_callback);
                 }
             },
-            enter: () => {
+            a: () => {
                 if(!this.expanded){
                     this.choosen_ability = this.abilities[this.ability_index];
                     this.hide(this.close_callback);
                 }
             }
-        }, {horizontal_loop:true, vertical_loop:true});
+        },{loop_configs: {vertical:true, horizontal:true}});
     }
 
     open(char, close_callback, set_description, expanded = false, djinn = null, next_djinn_status = null) {

--- a/base/windows/battle/SummonWindow.ts
+++ b/base/windows/battle/SummonWindow.ts
@@ -211,20 +211,20 @@ export class SummonWindow {
     }
 
     summon_choose(){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             left: this.previous_page.bind(this),
             right: this.next_page.bind(this),
             up: this.previous_summon.bind(this),
             down: this.next_summon.bind(this),
-            esc: () => {
+            b: () => {
                 this.choosen_ability = null;
                 this.close(this.close_callback);
             },
-            enter: () => {
+            a: () => {
                 this.choosen_ability = this.summons[this.summon_index].key_name;
                 this.hide(this.close_callback);
             }
-        },{horizontal_loop:true, vertical_loop:true});
+        },{loop_configs: {vertical:true, horizontal:true}});
     }
 
     open(char:MainChar, close_callback:Function, set_description:Function, djinni_already_used?:{[element: string]: number}) {

--- a/base/windows/djinn/DjinnListWindow.ts
+++ b/base/windows/djinn/DjinnListWindow.ts
@@ -457,15 +457,15 @@ export class DjinnListWindow {
 
     
     grant_control(on_cancel:Function, on_select:Function, on_shift?:Function){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             right: this.next_character.bind(this),
             left: this.previous_character.bind(this),
             up: this.previous_djinni.bind(this),
             down: this.next_djinni.bind(this),
-            esc: on_cancel,
-            enter: on_select,
-            shift: on_shift,
-        }, {horizontal_loop:true, vertical_loop:true});
+            b: on_cancel,
+            a: on_select,
+            l: on_shift,
+        },{loop_configs: {vertical:true, horizontal:true}});
     }
 
     darken_font_color(darken = true) {

--- a/base/windows/djinn/DjinnPsynergyWindow.ts
+++ b/base/windows/djinn/DjinnPsynergyWindow.ts
@@ -85,17 +85,17 @@ export class DjinnPsynergyWindow {
     }
 
     grant_control(){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             left: this.previous_page.bind(this),
             right: this.next_page.bind(this),
-            spacebar: this.spacebar_callback,
-            esc: () => {
+            r: this.spacebar_callback,
+            b: () => {
                 this.execute_operation = false;
                 this.close(this.close_callback)},
-            enter: () => {
+            a: () => {
                 this.execute_operation = true;
                 this.close(this.close_callback)}
-        },{horizontal_loop:true});
+        },{loop_configs: {horizontal:true}});
     }
 
     set_page_number() {

--- a/base/windows/item/DropItemWindow.ts
+++ b/base/windows/item/DropItemWindow.ts
@@ -130,12 +130,12 @@ export class DropItemWindow {
             }
         }, false);
 
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             up: this.change_answer.bind(this),
             down: this.change_answer.bind(this),
-            esc: this.close.bind(this),
-            enter: this.on_drop.bind(this)
-        },{vertical_loop:true});
+            b: this.close.bind(this),
+            a: this.on_drop.bind(this)
+        },{loop_configs: {vertical:true}});
 
     }
 

--- a/base/windows/item/GiveItemWindow.ts
+++ b/base/windows/item/GiveItemWindow.ts
@@ -186,12 +186,13 @@ export class GiveItemWindow {
         if(this.asking_for_equip){
             this.set_header();
             this.set_answer_index(YES_Y);
-            this.data.control_manager.set_control({
+            
+            this.data.control_manager.set_main_control({
                 up: this.change_answer.bind(this),
                 down: this.change_answer.bind(this),
-                esc: this.on_give.bind(this, false),
-                enter: this.on_give.bind(this)
-            },{vertical_loop:true});
+                b: this.on_give.bind(this, false),
+                a: this.on_give.bind(this)
+            },{loop_configs: {vertical:true}});
         }
         else{
             if (this.item_obj.quantity > 1) {

--- a/base/windows/item/ItemOptionsWindow.ts
+++ b/base/windows/item/ItemOptionsWindow.ts
@@ -365,14 +365,13 @@ export class ItemOptionsWindow {
 
         this.choose_position(vertical, horizontal);
 
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             right: this.next_horizontal.bind(this),
             left: this.previous_horizontal.bind(this),
             up: this.next_vertical.bind(this),
             down: this.previous_vertical.bind(this),
-            esc: this.close.bind(this, this.close_callback),
-            enter: this.on_choose.bind(this)},
-            {horizontal_loop:true, vertical_loop:true});
+            b: this.close.bind(this, this.close_callback),
+            a: this.on_choose.bind(this)},{loop_configs: {vertical:true, horizontal:true}});
     }
 
     open(item_obj:ItemSlot, item:Item, char:MainChar, stats_window:StatsCheckWithItemWindow, item_menu:MainItemMenu,

--- a/base/windows/item/ItemQuantityManagerWindow.ts
+++ b/base/windows/item/ItemQuantityManagerWindow.ts
@@ -82,12 +82,12 @@ export class ItemQuantityManagerWindow {
     }
 
     grant_control(on_cancel:Function, on_select:Function){
-        this.data.control_manager.set_control({
+        this.data.control_manager.set_main_control({
             left: this.decrease_amount.bind(this),
             right: this.increase_amount.bind(this),
-            esc: on_cancel,
-            enter: on_select
-        }, {custom_loop_time:ITEM_COUNTER_LOOP_TIME, horizontal_loop:true})
+            b: on_cancel,
+            a: on_select
+        },{loop_configs: {horizontal:true, horizontal_time:ITEM_COUNTER_LOOP_TIME}});
     }
 
     increase_amount(){

--- a/base/windows/shop/BuySelectMenu.ts
+++ b/base/windows/shop/BuySelectMenu.ts
@@ -305,13 +305,17 @@ export class BuySelectMenu{
     }
 
     grant_control(on_cancel:Function, on_select:Function){
-        this.data.control_manager.set_control({right: this.next_item.bind(this),
+        this.data.control_manager.set_main_control({right: this.next_item.bind(this),
             left: this.previous_item.bind(this),
             up: this.previous_page.bind(this),
             down: this.next_page.bind(this),
-            esc: on_cancel,
-            enter: on_select},
-            {horizontal_loop:true});
+            b: on_cancel,
+            a: on_select},{loop_configs: {horizontal:true}});
+        this.data.control_manager.set_extra_control([
+            {label:"psy1", callback:() =>{
+                console.log("Pressed psy1 key");
+            }}
+        ])
     }
 
     /*Changes to the next item page

--- a/base/windows/shop/InventoryWindow.ts
+++ b/base/windows/shop/InventoryWindow.ts
@@ -187,13 +187,12 @@ export class InventoryWindow{
     }
 
     grant_control(on_cancel:Function, on_select:Function){
-        this.data.control_manager.set_control({right: this.next_col.bind(this),
+        this.data.control_manager.set_main_control({right: this.next_col.bind(this),
             left: this.previous_col.bind(this),
             up: this.previous_line.bind(this),
             down: this.next_line.bind(this),
-            esc: on_cancel,
-            enter: on_select},
-            {horizontal_loop:true, vertical_loop:true});
+            b: on_cancel,
+            a: on_select},{loop_configs: {vertical:true, horizontal:true}});
     }
 
     next_col(){

--- a/base/windows/shop/ShopItemQuantityWindow.ts
+++ b/base/windows/shop/ShopItemQuantityWindow.ts
@@ -66,11 +66,10 @@ export class ShopItemQuantityWindow {
     }
 
     grant_control(on_cancel:Function, on_select:Function){
-        this.data.control_manager.set_control({right: this.increase_amount.bind(this),
+        this.data.control_manager.set_main_control({right: this.increase_amount.bind(this),
             left: this.decrease_amount.bind(this),
-            esc: on_cancel,
-            enter: on_select},
-            {custom_loop_time:ITEM_COUNTER_LOOP_TIME, horizontal_loop:true});
+            b: on_cancel,
+            a: on_select},{loop_configs: {horizontal:true, horizontal_time: ITEM_COUNTER_LOOP_TIME}});
     }
 
     increase_amount(){


### PR DESCRIPTION
### Major refactor in `ControlManager.ts`:
- Now uses `Gamepad.ts` as a base for its inputs.
- Keys are now divided in `main_keys` and `extra_keys`.
- Any main key can be looped and corresponds to a GBA input.
- Any number of `extra_keys` is supported.
- Refactored all previous uses of `set_control` to match the new updates.

### Introduced `Gamepad.ts`:
- This class defines all inputs in the game.
- Separates keys into `main_keys` and `extra_keys`.
- `main_keys` are correspond to GBA inputs.
- Default inputs changed (mostly for testing purposes).

### New default keys:
- A Key - Keyboard Z
- B Key - Keyboard X
- L Key - Keyboard A
- R Key - Keyboard S
- Select Key - Keyboard Backspace
- Start Key - Keyboard Enter
- All other keys remain unchanged.

### Resolved previous hard-coded key instances:
- Running with shift (B Key by default)
- Opening main menu (A Key by default. Added Select Key as well.)
- Interacting with objects/npcs (A Key by default)
- Rotating battle camera (same keys: PgUp and PgDown)
- Moving and canceling movement in Move Psynergy (B Key to cancel)
- All debug functions and extra shortcuts refactored to use the Gamepad.