### PR TITLE
Fix bug that makes tiles disappear after battles.

### DIFF
--- a/base/battle/PlayerSprite.ts
+++ b/base/battle/PlayerSprite.ts
@@ -336,7 +336,6 @@ export class PlayerSprite {
         });
 
         await promise;
-        bmd.destroy();
         img.destroy();
         this.deactive();
     }


### PR DESCRIPTION
This PR is an attempt at fixing #297. Not sure if this is the right fix, but since the `bmd` object is added to the `img` group which gets destroyed explicitly, I assume everything else is cleaned up correctly?

How to test:
* Go to the overworld
* Initiate a battle
* After the battle, go back to a map and all tiles should be shown without flashing


btw. huge fan of this repo and your work. This is awesome.