### PR TITLE
Fix InventoryWindow.previous_col when the selected row is empty

### DIFF
--- a/base/windows/shop/InventoryWindow.ts
+++ b/base/windows/shop/InventoryWindow.ts
@@ -240,7 +240,7 @@ export class InventoryWindow {
     }
 
     previous_col() {
-        if (this.item_grid.length === 1 && this.item_grid[this.cursor_pos.line].length === 1) return;
+        if (this.item_grid.length === 1 && this.item_grid[this.cursor_pos.line]?.length === 1) return;
 
         if (this.cursor_pos.col > 0) {
             this.set_cursor(this.cursor_pos.line, this.cursor_pos.col - 1);


### PR DESCRIPTION
Fixes the Shop soft lock from #444.