### PR TITLE
Allow selecting downed characters when casting revive

### DIFF
--- a/assets/dbs/abilities_db.json
+++ b/assets/dbs/abilities_db.json
@@ -198,7 +198,8 @@
         "ability_category": "psynergy",
         "battle_animation_key": "revive",
         "priority_move": false,
-        "msg_type": "cast"
+        "msg_type": "cast",
+        "affects_downed": true
     },{
         "key_name": "flare",
         "name": "Flare",

--- a/base/Ability.ts
+++ b/base/Ability.ts
@@ -118,6 +118,7 @@ export class Ability {
     public affects_pp: boolean;
     public has_animation_variation: boolean;
     public can_be_mirrored: boolean;
+    public affects_downed: boolean;
 
     constructor(
         key_name,
@@ -144,7 +145,8 @@ export class Ability {
         msg_type,
         affects_pp,
         has_animation_variation,
-        can_be_mirrored
+        can_be_mirrored,
+        affects_downed
     ) {
         this.key_name = key_name;
         this.name = name;
@@ -171,6 +173,7 @@ export class Ability {
         this.affects_pp = affects_pp ?? false;
         this.has_animation_variation = has_animation_variation ?? false;
         this.can_be_mirrored = can_be_mirrored ?? false;
+        this.affects_downed = affects_downed ?? false;
     }
 
     static get_diminishing_ratios(

--- a/base/battle/Battle.ts
+++ b/base/battle/Battle.ts
@@ -219,7 +219,8 @@ export class Battle {
                     this.target_window.close();
                 }
                 callback(targets);
-            }
+            },
+            this_ability.affects_downed
         );
     }
 
@@ -576,11 +577,11 @@ export class Battle {
             return;
         }
 
-        //check whether all targets are downed and change ability to "defend" in the case it's true
-        this.check_if_all_targets_are_downed(action);
-
         //gets the ability of this phase
         let ability = await this.get_phase_ability(action);
+
+        //check whether all targets are downed and change ability to "defend" in the case it's true
+        if (!ability.affects_downed) this.check_if_all_targets_are_downed(action);
 
         //gets item's name in the case this ability is related to an item
         let item_name = action.item_slot ? this.data.info.items_list[action.item_slot.key_name].name : "";

--- a/base/initializers/abilities.ts
+++ b/base/initializers/abilities.ts
@@ -48,7 +48,8 @@ export function initialize_abilities(
             ability_data.msg_type,
             ability_data.affects_pp,
             ability_data.has_animation_variation,
-            ability_data.can_be_mirrored
+            ability_data.can_be_mirrored,
+            ability_data.affects_downed
         );
     }
     const loader = game.load.atlasJSONHash(


### PR DESCRIPTION
Adds a field "affects_downed" to abilities which allows targeting downed characters when casting. Also when casting this type of ability, cursor is initially placed on a downed character if one exists. 
![revive_cursor_fixed](https://user-images.githubusercontent.com/40727683/207499633-8f47def3-443a-4b6d-96f3-cdcc71df814b.gif)

Issue: https://github.com/jjppof/goldensun_html5/issues/192
