### PR TITLE
Fix sfx for unsuccessful purchases in shop

### DIFF
--- a/base/support_menus/CharsMenu.ts
+++ b/base/support_menus/CharsMenu.ts
@@ -402,7 +402,13 @@ export class CharsMenu {
         this.change_line(new_line, new_index);
     }
 
-    grant_control(on_cancel?: Function, on_select?: Function, enable_swap?: boolean, extra_controls?: Control[]) {
+    grant_control(
+        on_cancel?: Function,
+        on_select?: Function,
+        enable_swap?: boolean,
+        extra_controls?: Control[],
+        confirm_sfx?: string | (() => string)
+    ) {
         const controls = [
             {buttons: Button.LEFT, on_down: this.previous_char.bind(this), sfx: {down: "menu/move"}},
             {buttons: Button.RIGHT, on_down: this.next_char.bind(this), sfx: {down: "menu/move"}},
@@ -413,7 +419,7 @@ export class CharsMenu {
                 buttons: Button.A,
                 on_down: () => on_select?.(),
                 params: {reset_controls: true},
-                sfx: {down: "menu/positive"},
+                sfx: {down: confirm_sfx ? confirm_sfx : "menu/positive"},
             },
             {
                 buttons: Button.B,

--- a/base/support_menus/HorizontalMenu.ts
+++ b/base/support_menus/HorizontalMenu.ts
@@ -116,7 +116,7 @@ export class HorizontalMenu {
         this.mount_buttons();
     }
 
-    set_controls(confirm_sfx?: string) {
+    set_controls(confirm_sfx?: string | (() => string)) {
         const controls = [
             {buttons: Button.LEFT, on_down: this.previous_button.bind(this), sfx: {down: "menu/move"}},
             {buttons: Button.RIGHT, on_down: this.next_button.bind(this), sfx: {down: "menu/move"}},
@@ -225,7 +225,7 @@ export class HorizontalMenu {
         select_index: number = 0,
         start_active: boolean = true,
         custom_scale?: {active_default: number; max_scale: number},
-        confirm_sfx?: string
+        confirm_sfx?: string | (() => string)
     ) {
         this.reset_button();
 

--- a/base/windows/YesNoMenu.ts
+++ b/base/windows/YesNoMenu.ts
@@ -19,6 +19,8 @@ export class YesNoMenu {
     public is_open: boolean;
     public menu: HorizontalMenu;
 
+    public confirm_sfx: string;
+
     constructor(game: Phaser.Game, data: GoldenSun) {
         this.game = game;
         this.data = data;
@@ -29,6 +31,7 @@ export class YesNoMenu {
         this.buttons_keys = [actions.YES_ACTION, actions.NO_ACTION];
 
         this.is_open = false;
+        this.confirm_sfx = undefined;
 
         this.menu = new HorizontalMenu(
             this.game,
@@ -82,9 +85,9 @@ export class YesNoMenu {
             this.data.hero.stop_char();
             this.data.hero.update_shadow();
         }
-
+        this.confirm_sfx = confirm_sfx;
         this.is_open = true;
-        this.menu.open(open_callback, 0, true, undefined, confirm_sfx);
+        this.menu.open(open_callback, 0, true, undefined, this.get_confirm_sfx.bind(this));
 
         if (custom_pos) {
             this.update_position(custom_pos.x, custom_pos.y);
@@ -101,5 +104,13 @@ export class YesNoMenu {
 
     destroy() {
         this.menu.destroy();
+    }
+
+    get_confirm_sfx() {
+        if (this.confirm_sfx && this.buttons_keys[this.menu.selected_button_index] == actions.YES_ACTION) {
+            return this.confirm_sfx;
+        } else {
+            return "menu/positive";
+        }
     }
 }

--- a/base/windows/item/UseGiveItemWindow.ts
+++ b/base/windows/item/UseGiveItemWindow.ts
@@ -354,6 +354,7 @@ export class UseGiveItemWindow {
             const controls = [
                 {buttons: Button.UP, on_down: this.change_answer.bind(this), sfx: {down: "menu/move"}},
                 {buttons: Button.DOWN, on_down: this.change_answer.bind(this), sfx: {down: "menu/move"}},
+                // in the original games, the item equip sfx is played whether or not the item is actually equipped
                 {buttons: Button.A, on_down: this.on_give.bind(this), sfx: {down: "menu/item_equip"}},
                 {buttons: Button.B, on_down: this.on_give.bind(this, false), sfx: {down: "menu/negative"}},
             ];

--- a/base/windows/shop/BuyArtifactsMenu.ts
+++ b/base/windows/shop/BuyArtifactsMenu.ts
@@ -157,6 +157,7 @@ export class BuyArtifactsMenu {
         let promise_resolve;
         const promise = new Promise(resolve => (promise_resolve = resolve));
         const cursed_msg_win = new Window(this.game, 64, 32, 140, 20);
+        this.data.audio.play_se("on_equip_curse");
         cursed_msg_win.set_text_in_position("You've been cursed!", undefined, undefined, {italic: true});
         cursed_msg_win.show(() => {
             this.data.control_manager.add_simple_controls(() => {
@@ -344,7 +345,9 @@ export class BuyArtifactsMenu {
 
                             this.yesno_action.open(
                                 {yes: this.equip_new_item.bind(this), no: this.check_game_ticket.bind(this)},
-                                {x: YESNO_X, y: YESNO_Y}
+                                {x: YESNO_X, y: YESNO_Y},
+                                undefined,
+                                "menu/item_equip"
                             );
                         };
                         this.data.control_manager.add_simple_controls(equip_now.bind(this));
@@ -389,7 +392,7 @@ export class BuyArtifactsMenu {
                     {yes: this.on_purchase_success.bind(this, false, false), no: this.open_equip_compare.bind(this)},
                     {x: YESNO_X, y: YESNO_Y},
                     undefined,
-                    "menu/shop_buy"
+                    this.get_purchase_confirm_sfx()
                 );
             } else {
                 this.on_purchase_success(true, undefined, true);
@@ -517,7 +520,22 @@ export class BuyArtifactsMenu {
             this.show_windows(open_windows, () => {
                 this.char_display.grant_control(
                     this.on_cancel_char_select.bind(this),
-                    this.on_buy_equip_select.bind(this)
+                    this.on_buy_equip_select.bind(this),
+                    undefined,
+                    undefined,
+                    () => {
+                        this.selected_character = this.char_display.selected_index
+                            ? this.char_display.lines[this.char_display.current_line][this.char_display.selected_index]
+                            : null;
+                        let curr_char = this.selected_character
+                            ? this.selected_character
+                            : this.data.info.party_data.members[0];
+                        return this.data.info.items_list[this.selected_item.key_name].equipable_chars.includes(
+                            curr_char.key_name
+                        )
+                            ? this.get_purchase_confirm_sfx(false)
+                            : "menu/positive";
+                    }
                 );
             });
         });
@@ -553,7 +571,10 @@ export class BuyArtifactsMenu {
                 let give_control = () => {
                     this.char_display.grant_control(
                         game_ticket ? this.on_cancel_game_ticket.bind(this) : this.on_cancel_char_select.bind(this),
-                        this.on_buy_item_select.bind(this, game_ticket)
+                        this.on_buy_item_select.bind(this, game_ticket),
+                        undefined,
+                        undefined,
+                        this.get_purchase_confirm_sfx.bind(this, game_ticket, "menu/positive")
                     );
                 };
 
@@ -707,5 +728,36 @@ export class BuyArtifactsMenu {
         Promise.all(promises).then(() => {
             on_complete();
         });
+    }
+
+    // todo: refactor so this logic doesn't have to be repeated twice when buying an item
+    get_purchase_confirm_sfx(game_ticket: boolean = false, confirm_sfx?: string) {
+        this.selected_character = this.char_display.selected_index
+            ? this.char_display.lines[this.char_display.current_line][this.char_display.selected_index]
+            : null;
+        let curr_char = this.selected_character ? this.selected_character : this.data.info.party_data.members[0];
+
+        let quantity = 1;
+        let item_to_receive = game_ticket ? GAME_TICKET_KEY_NAME : this.selected_item.key_name;
+        let have_quant = 0;
+
+        for (let i = 0; i < curr_char.items.length; i++) {
+            let itm = curr_char.items[i];
+            if (itm.key_name === item_to_receive) {
+                have_quant = itm.quantity;
+            }
+        }
+        if (this.quant_win.is_open && !game_ticket) quantity = this.quant_win.chosen_quantity;
+
+        let not_enough_coins =
+            !game_ticket &&
+            this.data.info.party_data.coins - this.data.info.items_list[this.selected_item.key_name].price * quantity <
+                0;
+        let inventory_full =
+            curr_char.items.length === MainChar.MAX_ITEMS_PER_CHAR &&
+            !(0 < have_quant && have_quant < MainChar.MAX_ITEMS_PER_CHAR);
+        let stack_full = have_quant === MainChar.MAX_GENERAL_ITEM_NUMBER;
+        if (not_enough_coins || inventory_full || stack_full) return "menu/negative";
+        else return confirm_sfx ? confirm_sfx : "menu/shop_buy";
     }
 }

--- a/base/windows/shop/BuyArtifactsMenu.ts
+++ b/base/windows/shop/BuyArtifactsMenu.ts
@@ -237,7 +237,7 @@ export class BuyArtifactsMenu {
         }
     }
 
-    on_purchase_success(equip_ask: boolean = false, game_ticket: boolean = false, play_sfx: boolean = false) {
+    on_purchase_success(equip_ask: boolean = false, game_ticket: boolean = false) {
         let quantity = 1;
         let key_name = game_ticket ? GAME_TICKET_KEY_NAME : this.selected_item.key_name;
         let item_to_add = this.data.info.items_list[key_name];
@@ -260,7 +260,6 @@ export class BuyArtifactsMenu {
         } else {
             this.npc_dialog.update_dialog("after_buy", true);
             this.data.cursor_manager.hide();
-            if (play_sfx) this.data.audio.play_se("menu/shop_buy");
 
             let process_purchase = () => {
                 const item = this.data.info.items_list[this.selected_item.key_name];
@@ -395,7 +394,7 @@ export class BuyArtifactsMenu {
                     this.get_purchase_confirm_sfx()
                 );
             } else {
-                this.on_purchase_success(true, undefined, true);
+                this.on_purchase_success(true, undefined);
             }
         }
     }
@@ -440,7 +439,7 @@ export class BuyArtifactsMenu {
                 this.on_buy_item_select.bind(this, game_ticket)
             );
         } else {
-            if (game_ticket) this.on_purchase_success(false, game_ticket, true);
+            if (game_ticket) this.on_purchase_success(false, game_ticket);
             else {
                 if (
                     this.data.info.party_data.coins - this.data.info.items_list[this.selected_item.key_name].price <
@@ -574,7 +573,11 @@ export class BuyArtifactsMenu {
                         this.on_buy_item_select.bind(this, game_ticket),
                         undefined,
                         undefined,
-                        this.get_purchase_confirm_sfx.bind(this, game_ticket, "menu/positive")
+                        this.get_purchase_confirm_sfx.bind(
+                            this,
+                            game_ticket,
+                            game_ticket ? "menu/shop_buy" : "menu/positive"
+                        )
                     );
                 };
 

--- a/base/windows/shop/BuyArtifactsMenu.ts
+++ b/base/windows/shop/BuyArtifactsMenu.ts
@@ -157,7 +157,7 @@ export class BuyArtifactsMenu {
         let promise_resolve;
         const promise = new Promise(resolve => (promise_resolve = resolve));
         const cursed_msg_win = new Window(this.game, 64, 32, 140, 20);
-        this.data.audio.play_se("on_equip_curse");
+        this.data.audio.play_se("misc/on_equip_curse");
         cursed_msg_win.set_text_in_position("You've been cursed!", undefined, undefined, {italic: true});
         cursed_msg_win.show(() => {
             this.data.control_manager.add_simple_controls(() => {


### PR DESCRIPTION
Fixes sfx for failed shop transactions (inventory full, not enough coins, etc.) to menu/negative. Also fixed a bug in YesNo menu and added curse sound upon equipping when buying a cursed item from shop.

Working towards Issue #226 