### PR TITLE
Fix HP color in BasicInfoWindow

### DIFF
--- a/base/Window.ts
+++ b/base/Window.ts
@@ -1056,8 +1056,9 @@ export class Window {
      * @param text_obj The text object to be updated.
      * @param new_x
      * @param new_y
+     * @param color
      */
-    update_text(new_text: string, text_obj: TextObj) {
+    update_text(new_text: string, text_obj: TextObj, color?: number) {
         text_obj.text.setText(new_text);
         if (text_obj.shadow) {
             text_obj.shadow.setText(new_text);
@@ -1070,6 +1071,9 @@ export class Window {
             if (text_obj.text_bg) {
                 text_obj.text_bg.x = text_obj.text.x - 1;
             }
+        }
+        if (color) {
+            text_obj.text.tint = color;
         }
     }
 

--- a/base/magic_numbers.ts
+++ b/base/magic_numbers.ts
@@ -50,3 +50,4 @@ export const WORLD_MAP_SPEED_DASH_REDUCE = -45;
 export const WORLD_MAP_SPEED_WALK_REDUCE = -40;
 export const WORLD_MAP_SPRITE_SCALE_Y = 0.84;
 export const WORLD_MAP_SPRITE_SCALE_X = 0.84;
+export const LOW_HP_THRESHOLD = 0.25;

--- a/base/windows/BasicInfoWindow.ts
+++ b/base/windows/BasicInfoWindow.ts
@@ -1,5 +1,6 @@
 import {MainChar} from "../MainChar";
 import {TextObj, Window} from "../Window";
+import {LOW_HP_THRESHOLD, RED_FONT_COLOR, YELLOW_FONT_COLOR, DEFAULT_FONT_COLOR} from "../magic_numbers";
 
 const BASE_WIN_WIDTH = 100;
 const BASE_WIN_HEIGHT = 92;
@@ -143,7 +144,7 @@ export class BasicInfoWindow {
         this.base_window.update_text(this.char.name, this.name_text);
         this.base_window.update_text(this.char.level.toString(), this.lv_text);
         this.base_window.update_text(this.char.class.name, this.class_text);
-        this.base_window.update_text(this.char.current_hp.toString(), this.hp_text);
+        this.base_window.update_text(this.char.current_hp.toString(), this.hp_text, this.get_hp_color());
         this.base_window.update_text(this.char.current_pp.toString(), this.pp_text);
         this.base_window.update_text(this.char.max_hp.toString(), this.max_hp_text);
         this.base_window.update_text(this.char.max_pp.toString(), this.max_pp_text);
@@ -203,5 +204,12 @@ export class BasicInfoWindow {
                 callback();
             }
         }, false);
+    }
+
+    get_hp_color() {
+        let curr_char = this.char;
+        if (curr_char.current_hp <= 0) return RED_FONT_COLOR;
+        else if (curr_char.current_hp <= curr_char.max_hp * LOW_HP_THRESHOLD) return YELLOW_FONT_COLOR;
+        else return DEFAULT_FONT_COLOR;
     }
 }

--- a/base/windows/CharsStatusWindow.ts
+++ b/base/windows/CharsStatusWindow.ts
@@ -32,8 +32,6 @@ const STANDBY_COUNT_SHIFT_Y = [8, 16];
 const INITIAL_PADDING__DJINNI_X = 9;
 const INITIAL_PADDING__DJINNI_Y = 9;
 
-const LOW_HP_THRESHOLD = 0.25;
-
 type InfoSprite = {
     group: Phaser.Group;
     name: TextObj;
@@ -382,7 +380,7 @@ export class CharsStatusWindow {
 
     get_char_hp_color(curr_char: MainChar) {
         if (curr_char.current_hp <= 0) return numbers.RED_FONT_COLOR;
-        else if (curr_char.current_hp <= curr_char.max_hp * LOW_HP_THRESHOLD) return numbers.YELLOW_FONT_COLOR;
+        else if (curr_char.current_hp <= curr_char.max_hp * numbers.LOW_HP_THRESHOLD) return numbers.YELLOW_FONT_COLOR;
         else return this.status_window.font_color;
     }
 }


### PR DESCRIPTION
Makes HP turn yellow when low and red when zero when looking at psynergy or items

![hp_color_in_basic_info_window](https://user-images.githubusercontent.com/40727683/214775276-466e525a-16d6-4c30-9b3b-3d8a4ab5726e.gif)
